### PR TITLE
fix bug in expressionify

### DIFF
--- a/Z80IL.py
+++ b/Z80IL.py
@@ -189,9 +189,6 @@ def operand_to_il(oper_type, oper_val, il, size_hint=0, peel_load=False):
 def expressionify(size, foo, il, temps_are_conds=False):
     """ turns the "reg or constant"  operands to get_flag_write_low_level_il()
         into lifted expressions """
-    if isinstance(foo, int):
-        return foo
-
     if isinstance(foo, ILRegister):
         # LowLevelILExpr is different than ILRegister
         if temps_are_conds and LLIL_TEMP(foo.index):


### PR DESCRIPTION
remove extra if at start that returns ints as-is, which means constants get interpreted as indices and it gives hilarious effects (e.g. flag calculating A with PUSH(BC) which then evaluates the push and throws the stack off)