### PR TITLE
Implement DAA (and associated BCD flags)

### DIFF
--- a/ColecoView.py
+++ b/ColecoView.py
@@ -168,5 +168,9 @@ class ColecoView(BinaryView):
 	def perform_get_entry_point(self):
 		return 0
 
+	# undocumented but looks to match arch.address_size
+	# so should be in bytes and should equal arch.address_size
+	# but this breaks .synthetic_builtins when the rom mapping uses the whole memory
+	# so we'll leave it at 8
 	def perform_get_address_size(self):
-	    return 2
+		return 8

--- a/Z80IL.py
+++ b/Z80IL.py
@@ -209,9 +209,6 @@ def exchange(lhs_reg, rhs_reg, il):
 def expressionify(size, foo, il, temps_are_conds=False):
     """ turns the "reg or constant"  operands to get_flag_write_low_level_il()
         into lifted expressions """
-    if isinstance(foo, int):
-        return foo
-
     if isinstance(foo, ILRegister):
         # LowLevelILExpr is different than ILRegister
         if temps_are_conds and LLIL_TEMP(foo.index):

--- a/Z80IL.py
+++ b/Z80IL.py
@@ -286,7 +286,7 @@ def gen_flag_il(op, size, write_type, flag, operands, il):
             result = il.sub(size, expressionify(size, operands[0], il), expressionify(size, operands[1], il))
             result_bottom_nybble = il.and_expr(size, result, il.const(size, 0x0F))
             return il.compare_unsigned_greater_than(size, result_bottom_nybble, original_bottom_nybble)
-        if op == LowLevelILOperation.LLIL_SUB:
+        if op == LowLevelILOperation.LLIL_SBB:
             # we've overflowed bottom nybble if it's higher after a sbc
             original_bottom_nybble = il.and_expr(size, expressionify(size, operands[0], il), il.const(size, 0x0F))
             result = il.sub_borrow(size, expressionify(size, operands[0], il), expressionify(size, operands[1], il), il.flag("c"))

--- a/Z80IL.py
+++ b/Z80IL.py
@@ -602,7 +602,7 @@ def gen_instr_il(addr, decoded, il):
 
     elif decoded.op in [OP.RR, OP.RRA]:
         # rotate THROUGH carry: b7=c, c=b0
-        # z80 'RL' -> llil 'RRC'
+        # z80 'RR' -> llil 'RRC'
         if decoded.op == OP.RRA:
             src = il.reg(1, 'A')
         else:
@@ -611,6 +611,24 @@ def gen_instr_il(addr, decoded, il):
         rot = il.rotate_right_carry(1, src, il.const(1, 1), il.flag('c'), flags='c')
 
         if decoded.op == OP.RRA:
+            il.append(il.set_reg(1, 'A', rot))
+        elif oper_type == OPER_TYPE.REG:
+            il.append(il.set_reg(1, reg2str(oper_val), rot))
+        else:
+            tmp2 = operand_to_il(oper_type, oper_val, il, 1, peel_load=True)
+            il.append(il.store(1, tmp2, rot))
+
+    elif decoded.op in [OP.RRC, OP.RRCA]:
+        # rotate and COPY to carry: b0=c, c=b8
+        # z80 'RR' -> llil 'ROR'
+        if decoded.op == OP.RRCA:
+            src = il.reg(1, 'A')
+        else:
+            src = operand_to_il(oper_type, oper_val, il, 1)
+
+        rot = il.rotate_right(1, src, il.const(1, 1), flags='c')
+
+        if decoded.op == OP.RRCA:
             il.append(il.set_reg(1, 'A', rot))
         elif oper_type == OPER_TYPE.REG:
             il.append(il.set_reg(1, reg2str(oper_val), rot))


### PR DESCRIPTION
This was fun, I'm not super concerned about flag output (except Z and C), it looks kinda nice in IL:

![image](https://github.com/Vector35/Z80/assets/1481279/0d58512d-6d31-44e0-a845-e0b7af15b53d)

Looks a bit wild with the full flag calculation in the HLIL though:

![image](https://github.com/Vector35/Z80/assets/1481279/11ffede5-dc13-4725-9b54-a1d92375cd46)

![image](https://github.com/Vector35/Z80/assets/1481279/1529d1ef-a672-4c03-945e-45af6b51a547)

![image](https://github.com/Vector35/Z80/assets/1481279/7d123a22-2e40-4a9b-9efa-5a03886abd26)

Note that I've manually implemented the half-carry and it seems to resolve to the same as the default for carry implementation in the HLIL

