### PR TITLE
Fix two loader bugs (#17, #19)

### DIFF
--- a/ColecoView.py
+++ b/ColecoView.py
@@ -26,7 +26,7 @@ class ColecoView(BinaryView):
 		# data is a binaryninja.binaryview.BinaryView
 		if len(data.read(0,0xc000)) == 0xc000:
 			if self.is_valid_cartridge_header(data.read(0x8000, 12)):
-				if data.read(0, 16) == '\x31\xb9\x73\xc3\x6e\x00\xff\xff\xc3\x0c\x80\xff\xff\xff\xff\xc3':
+				if data.read(0, 16) == b'\x31\xb9\x73\xc3\x6e\x00\xff\xff\xc3\x0c\x80\xff\xff\xff\xff\xc3':
 					print('detected ColecoVision system image')
 					return 'system'
 

--- a/RelView.py
+++ b/RelView.py
@@ -29,7 +29,7 @@ class RelView(BinaryView):
         syms = []
         have_code = False
 
-        for line in self.parent_view.read(0, len(self.parent_view)).split(b'\x0a'):
+        for line in self.parent_view.read(0, self.parent_view.end).split(b'\x0a'):
             line = line.decode('utf-8')
 
             # AREA line -> create a section
@@ -81,3 +81,6 @@ class RelView(BinaryView):
 
     def perform_get_entry_point(self):
         return 0
+
+    def perform_get_address_size(self):
+        return 2


### PR DESCRIPTION
Two independent one-line-ish loader fixes.

## RelView.py — fixes #17

`init()` called `len(self.parent_view)`, which raises
`TypeError: object of type "BinaryView" has no len()` on Binary Ninja 6.0.
`init()` aborted, so `.rel` objects loaded with **0 segments**. Switched to
`self.parent_view.end`.

Also implemented `perform_get_address_size()` (returns 2), which was raising
`NotImplementedError` from `BinaryView._get_address_size`.

Before / after on an sdcc `.rel` object:

| | segments |
|---|---|
| before | 0 |
| after | 2 |

**Note:** the view still ends up with 0 functions. `add_auto_segment()` is
called with a data length of 0, so the segment has no file backing and
Binary Ninja refuses to place functions in it:

```
Analysis error: Attempting to add function not backed by file: 0x37
```

That is a separate, pre-existing problem — the `.rel` format is textual, so
the code bytes come from `T` records rather than a contiguous file region,
and backing the segment with the file instead corrupts the parent view on
reload. Filed separately rather than widening this PR.

## ColecoView.py — fixes #19

`get_rom_type()` compared `data.read(0, 16)` (`bytes`) against a `str`
literal, which is never equal on Python 3, so the `system` branch was
unreachable and BIOS+cartridge images fell back to a raw `Mapped` view.

Verified with a synthesised 0xC000 system image (signature bytes at 0, an
MIT-licensed cartridge at 0x8000 — no BIOS code):

| | view type | segments | functions |
|---|---|---|---|
| before | `Mapped` | 2 | 12 |
| after | `Coleco` (logs "detected ColecoVision system image") | 4 | 50 |

Plain cartridge ROMs still detect as before (`Coleco`, 4 segments) — no
regression.